### PR TITLE
shell script for backend init (issue #8)

### DIFF
--- a/backend/SNUBot/init.sh
+++ b/backend/SNUBot/init.sh
@@ -1,0 +1,6 @@
+pip install django
+pip install django-cors-headers
+python3 manage.py makemigrations
+python3 manage.py migrate
+python3 manage.py createsuperuser
+python3 manage.py shell < ./bot.py


### PR DESCRIPTION
백엔드 DB 초기화 자동화를 위한 코드로 빨리 올리는게 좋다고 생각해서 PR 빨리 올립니다

## 실행방법
`backend` 디렉토리에서
`./init.sh`
후에 superuser 만들때만 instruction을 따르면 됩니다.

만약 `./init.sh` 가 안되면
`chmod +x init.sh` 후에 `./init.sh`
하시면 됩니다.
