### PR TITLE
Frontend signin fixes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,24 +31,28 @@ export class App extends Component {
       <ConnectedRouter history={this.props.history}>
         <div className="App">
           <Switch>
-            <Redirect exact from="/" to="/signin" />
+            <Redirect exact from="/" to="/chat" />
 
             <Route path="/chat" exact component={Chat} />
             <Route path="/boards" exact component={CommunityMain} />
 
-            <Route path="/boards/:boardName" exact component={BoardDetail} />
             <Route
-              path="/boards/:boardName/create"
+              path="/boards/:boardName([A-Za-z]+)"
+              exact
+              component={BoardDetail}
+            />
+            <Route
+              path="/boards/:boardName([A-Za-z]+)/create"
               exact
               component={ArticleCreate}
             />
             <Route
-              path="/boards/:boardName/:articleId"
+              path="/boards/:boardName([A-Za-z]+)/:articleId([0-9]+)"
               exact
               component={ArticleDetail}
             />
             <Route
-              path="/boards/:boardName/:articleId/edit"
+              path="/boards/:boardName([A-Za-z]+)/:articleId([0-9]+)/edit"
               exact
               component={ArticleEdit}
             />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,7 +31,7 @@ export class App extends Component {
       <ConnectedRouter history={this.props.history}>
         <div className="App">
           <Switch>
-            <Redirect exact from="/" to="/chat" />
+            <Redirect exact from="/" to="/signin" />
 
             <Route path="/chat" exact component={Chat} />
             <Route path="/boards" exact component={CommunityMain} />

--- a/frontend/src/containers/Community/BoardDetail/BoardDetail.js
+++ b/frontend/src/containers/Community/BoardDetail/BoardDetail.js
@@ -36,7 +36,7 @@ class BoardDetail extends Component {
             <tr>
               <th>ArticleID</th>
               <th>Title</th>
-              <th>Auther</th>
+              <th>Author</th>
               <th>tag</th>
             </tr>
           </thead>

--- a/frontend/src/containers/User/Signin/Signin.js
+++ b/frontend/src/containers/User/Signin/Signin.js
@@ -20,11 +20,16 @@ class Signin extends Component {
 
   render() {
     const SigninHandler = () => {
-      this.props.Signin(this.state.username, this.state.password);
+      const username = this.state.username;
+      const password = this.state.password;
+      this.setState({ password: '' });
+      this.props.signin(username, password);
     };
     return (
       <div className="Signin">
-        <Button id="direct-to-signup" onClick={() => this.props.history.push('/signup')}>
+        <Button
+          id="direct-to-signup"
+          onClick={() => this.props.history.push('/signup')}>
           go to signup page
         </Button>
         <h1>Need Signin!</h1>
@@ -39,10 +44,14 @@ class Signin extends Component {
         <input
           id="pw-input"
           type="password"
-          value={this.state.content}
+          value={this.state.password}
           onChange={(event) => this.setState({ password: event.target.value })}
         />
-        <Button id="Signin-button" onClick={() => SigninHandler()}>
+        <Button
+          id="Signin-button"
+          onClick={() => SigninHandler()}
+          disabled={!this.state.username || !this.state.password}
+        >
           Signin
         </Button>
       </div>
@@ -51,7 +60,8 @@ class Signin extends Component {
 }
 
 const mapDispatchToProps = (dispatch) => ({
-  Signin: (username, password) => dispatch(actionCreators.signin(username, password)),
+  signin: (username, password) =>
+    dispatch(actionCreators.signin(username, password)),
 });
 
 export default connect(

--- a/frontend/src/containers/User/Signin/Signin.test.js
+++ b/frontend/src/containers/User/Signin/Signin.test.js
@@ -7,7 +7,7 @@ import { ConnectedRouter } from 'connected-react-router';
 import Signin from './Signin';
 import { getMockStore } from '../../../test-utils/mocks';
 import { history } from '../../../store/store';
-import * as ActionCreators from '../../../store/actions/article';
+import * as ActionCreators from '../../../store/actions/user';
 
 const stubArticleInitialState = {
 
@@ -23,6 +23,7 @@ const mockStore = getMockStore(
 
 describe('<Signin />', () => {
   let signin;
+  let spySignin;
   beforeEach(() => {
     signin = (
       <Provider store={mockStore}>
@@ -33,6 +34,9 @@ describe('<Signin />', () => {
         </ConnectedRouter>
       </Provider>
     );
+    spySignin = jest
+      .spyOn(ActionCreators, 'signin')
+      .mockImplementation(() => (dispatch) => { });
   });
 
   afterEach(() => {
@@ -43,5 +47,37 @@ describe('<Signin />', () => {
     const component = mount(signin);
     const wrapper = component.find('.Signin');
     expect(wrapper.length).toBe(1);
+  });
+
+  it('input username and password, call Signin', () => {
+    const wrapper = mount(signin);
+    const usernameInput = wrapper.find('#username-input');
+    const passwordInput = wrapper.find('#pw-input');
+    const buttonInput = wrapper.find('#Signin-button').at(0);
+
+    const testUsername = 'test_username';
+    const passwordShort = 'short';
+
+    usernameInput.instance().value = testUsername;
+    usernameInput.simulate('change');
+
+    passwordInput.instance().value = passwordShort;
+    passwordInput.simulate('change');
+
+    expect(spySignin).toHaveBeenCalledTimes(0);
+    buttonInput.simulate('click');
+    expect(spySignin).toHaveBeenCalledTimes(1);
+    expect(spySignin).toHaveBeenCalledWith(testUsername, passwordShort);
+  });
+
+  it('goto signup page', () => {
+    const wrapper = mount(signin);
+    const buttonInput = wrapper.find('#direct-to-signup').at(0);
+
+    expect(history.length).toEqual(1);
+    expect(history.location.pathname).toBe('/');
+    buttonInput.simulate('click');
+    expect(history.length).toEqual(2);
+    expect(history.location.pathname).toBe('/signup');
   });
 });

--- a/frontend/src/containers/User/Signup/Signup.js
+++ b/frontend/src/containers/User/Signup/Signup.js
@@ -22,14 +22,19 @@ class Signup extends Component {
 
   render() {
     const SignupHandler = () => {
-      if (this.state.password.length < 8) {
-        alert('Password should be at least 8 characters');
-      } else if (this.state.password !== this.state.passwordConfirm) {
-        alert('Password and Password Confirm are not same');
-      } else {
-        this.props.Signup(this.state.email, this.state.username, this.state.password);
-      }
+      const email = this.state.email;
+      const username = this.state.username;
+      const password = this.state.password;
+      const passwordConfirm = this.state.passwordConfirm;
       this.setState({ password: '', passwordConfirm: '' });
+      if (password.length < 8) {
+        alert('Password should be at least 8 characters');
+      } else if (password !== passwordConfirm) {
+        alert('Password and Password Confirm are different');
+      } else {
+        this.props.signup(
+          email, username, password);
+      }
     };
     return (
       <div className="Signup">
@@ -89,7 +94,7 @@ class Signup extends Component {
 }
 
 const mapDispatchToProps = (dispatch) => ({
-  Signup: (email, username, password) =>
+  signup: (email, username, password) =>
     dispatch(actionCreators.signup(email, username, password)),
 });
 

--- a/frontend/src/containers/User/Signup/Signup.test.js
+++ b/frontend/src/containers/User/Signup/Signup.test.js
@@ -131,7 +131,8 @@ describe('<Signup />', () => {
     expect(passwordConfirmInput.instance().value).toEqual('');
     expect(spySignup).toHaveBeenCalledTimes(1);
     expect(spySignup).toHaveBeenCalledWith(
-      validEmail, validUsername, validPassword)
+      validEmail, validUsername, validPassword,
+    );
   });
 
   it('goto signin page', () => {

--- a/frontend/src/containers/User/Signup/Signup.test.js
+++ b/frontend/src/containers/User/Signup/Signup.test.js
@@ -7,7 +7,7 @@ import { ConnectedRouter } from 'connected-react-router';
 import Signup from './Signup';
 import { getMockStore } from '../../../test-utils/mocks';
 import { history } from '../../../store/store';
-import * as ActionCreators from '../../../store/actions/article';
+import * as ActionCreators from '../../../store/actions/user';
 
 const stubArticleInitialState = {
 
@@ -22,7 +22,13 @@ const mockStore = getMockStore(
 );
 
 describe('<Signup />', () => {
+  const validEmail = 'lightb0x@naver.com';
+  const validUsername = 'lightb0x';
+  const validPassword = 'password_test123';
+  const typoPassword = 'password-test123';
+  const shortPassword = 'short';
   let signup;
+  let spySignup;
   beforeEach(() => {
     signup = (
       <Provider store={mockStore}>
@@ -33,6 +39,9 @@ describe('<Signup />', () => {
         </ConnectedRouter>
       </Provider>
     );
+    spySignup = jest
+      .spyOn(ActionCreators, 'signup')
+      .mockImplementation(() => (dispatch) => { });
   });
 
   afterEach(() => {
@@ -55,36 +64,85 @@ describe('<Signup />', () => {
     const passwordConfirmInput = wrapper.find('#pw-confirm-input');
     const buttonInput = wrapper.find('#Signup-button').at(0);
 
-    emailInput.instance().value = 'a';
+    emailInput.instance().value = validEmail;
     emailInput.simulate('change');
 
-    usernameInput.instance().value = 'b';
+    usernameInput.instance().value = validUsername;
     usernameInput.simulate('change');
 
-    passwordInput.instance().value = 'c';
+    passwordInput.instance().value = shortPassword;
     passwordInput.simulate('change');
 
-    passwordConfirmInput.instance().value = 'd';
+    passwordConfirmInput.instance().value = shortPassword;
     passwordConfirmInput.simulate('change');
 
     expect(alertSpy).toHaveBeenCalledTimes(0);
-    expect(passwordInput.instance().value).toEqual('c');
-    expect(passwordConfirmInput.instance().value).toEqual('d');
+    expect(passwordInput.instance().value).toEqual(shortPassword);
+    expect(passwordConfirmInput.instance().value).toEqual(shortPassword);
     buttonInput.simulate('click');
     expect(passwordInput.instance().value).toEqual('');
     expect(passwordConfirmInput.instance().value).toEqual('');
     expect(alertSpy).toHaveBeenCalledTimes(1);
     expect(alertSpy)
       .toHaveBeenCalledWith('Password should be at least 8 characters');
+
+    passwordInput.instance().value = validPassword;
+    passwordInput.simulate('change');
+
+    passwordConfirmInput.instance().value = typoPassword;
+    passwordConfirmInput.simulate('change');
+
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(passwordInput.instance().value).toEqual(validPassword);
+    expect(passwordConfirmInput.instance().value).toEqual(typoPassword);
+    buttonInput.simulate('click');
+    expect(passwordInput.instance().value).toEqual('');
+    expect(passwordConfirmInput.instance().value).toEqual('');
+    expect(alertSpy).toHaveBeenCalledTimes(2);
+    expect(alertSpy)
+      .toHaveBeenCalledWith('Password and Password Confirm are different');
   });
 
-  // it('goto signin page', () => {
-  //   const wrapper = mount(signup);
-  //   const buttonInput = wrapper.find('#direct-to-signin').at(0);
+  it('input text and click button, success and call signup', () => {
+    const wrapper = mount(signup);
+    const emailInput = wrapper.find('#email-input');
+    const usernameInput = wrapper.find('#username-input');
+    const passwordInput = wrapper.find('#pw-input');
+    const passwordConfirmInput = wrapper.find('#pw-confirm-input');
+    const buttonInput = wrapper.find('#Signup-button').at(0);
 
-  //   buttonInput.simulate('click');
+    emailInput.instance().value = validEmail;
+    emailInput.simulate('change');
 
-  //   // expect();
-  // })
-  // TODO : historyMock is not applicable with this model
+    usernameInput.instance().value = validUsername;
+    usernameInput.simulate('change');
+
+    passwordInput.instance().value = validPassword;
+    passwordInput.simulate('change');
+
+    passwordConfirmInput.instance().value = validPassword;
+    passwordConfirmInput.simulate('change');
+
+    expect(passwordInput.instance().value).toEqual(validPassword);
+    expect(passwordConfirmInput.instance().value).toEqual(validPassword);
+    expect(spySignup).toHaveBeenCalledTimes(0);
+    buttonInput.simulate('click');
+    expect(passwordInput.instance().value).toEqual('');
+    expect(passwordConfirmInput.instance().value).toEqual('');
+    expect(spySignup).toHaveBeenCalledTimes(1);
+    expect(spySignup).toHaveBeenCalledWith(
+      validEmail, validUsername, validPassword)
+  });
+
+  it('goto signin page', () => {
+    const wrapper = mount(signup);
+    const buttonInput = wrapper.find('#direct-to-signin').at(0);
+
+    expect(history.length).toEqual(1);
+    expect(history.location.pathname).toBe('/');
+
+    buttonInput.simulate('click');
+    expect(history.length).toEqual(2);
+    expect(history.location.pathname).toBe('/signin');
+  });
 });


### PR DESCRIPTION
1. `/`으로 접속하면 `/signin` 대신 `/chat`으로
2. URL regex checks
3. signin, signup 테스트케이스들 추가
4. signin, signup 일부 버그 수정


기타 오탈자와 코딩 스타일에 맞지 않는 부분들 수정