### PR TITLE
Article and comment delete

### DIFF
--- a/backend/SNUBot/SNUBot/settings.py
+++ b/backend/SNUBot/SNUBot/settings.py
@@ -138,7 +138,7 @@ USE_TZ = True
 STATIC_URL = "/static/"
 
 CSRF_COOKIE_NAME = "csrftoken"
-CORS_ORIGIN_ALLOW_ALL = False
+CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS = True
 CORS_ORIGIN_WHITELIST = (
     "http://localhost",

--- a/backend/SNUBot/SNUBot/settings.py
+++ b/backend/SNUBot/SNUBot/settings.py
@@ -138,7 +138,7 @@ USE_TZ = True
 STATIC_URL = "/static/"
 
 CSRF_COOKIE_NAME = "csrftoken"
-CORS_ORIGIN_ALLOW_ALL = True
+CORS_ORIGIN_ALLOW_ALL = False
 CORS_ALLOW_CREDENTIALS = True
 CORS_ORIGIN_WHITELIST = (
     "http://localhost",

--- a/backend/SNUBot/community/tests.py
+++ b/backend/SNUBot/community/tests.py
@@ -1065,12 +1065,17 @@ class ArticleTestCase(TestCase):
         self.assertEqual(response.status_code, 400)
 
         comment_id = Comment.objects.get(content="test2").id
-        response = client.delete("/api/comment/0/")
+        response = client.delete("/api/comment/0/", data={
+            "commentId": -1,
+        }, content_type="application/json")
         self.assertEqual(response.status_code, 404)
 
-        response = client.delete("/api/comment/" + str(comment_id) + "/")
-        self.assertEqual(response.status_code, 403)
+        response = client.delete("/api/comment/" + str(comment_id) + "/",
+                                 content_type="application/json")
+        self.assertEqual(response.status_code, 400)
 
         comment_id = Comment.objects.get(content="test3").id
-        response = client.delete("/api/comment/" + str(comment_id) + "/")
-        self.assertEqual(response.status_code, 200)
+        response = client.delete("/api/comment/1/", data={
+            "commentId": comment_id,
+        }, content_type="application/json")
+        self.assertEqual(response.status_code, 204)

--- a/backend/SNUBot/community/views.py
+++ b/backend/SNUBot/community/views.py
@@ -157,14 +157,14 @@ def boards(request):
         return HttpResponseBadRequest()
     if tag == "all":
         article_list = [
-            article 
+            article
             for article in Article.objects.select_related("vote").filter(board=board_name).values(
                 "id", "title", "content", "author__nickname", "tag", "vote__like", "vote__dislike"
             )
         ]
     else:
         article_list = [
-            article 
+            article
             for article in Article.objects.select_related("vote").filter(board=board_name, tag=tag).values(
                 "id", "title", "content", "author__nickname", "tag", "vote__like", "vote__dislike"
             )
@@ -339,22 +339,24 @@ def comment(request, id):
         comment_json = list(comments)
         return JsonResponse(comment_json, status=201, safe=False)
     if request.method == "PUT":
+        print('put call')
         try:
+            print('1')
             req_data = json.loads(request.body.decode())
+            print('2')
             comment_id = req_data["commentId"]
+            print('3')
             content = req_data["content"]
+            print('4')
+            handle = req_data["handle"]
+            print('6')
         except (KeyError, JSONDecodeError):
             return HttpResponseBadRequest()
-        edit_comment = Comment.objects.get(pk=comment_id)
-        edit_comment.content = content
-        edit_comment.save()
-
-        return HttpResponse(status=201)
-    else:
-        comment = get_object_or_404(Comment, pk=id)
-        article_id = comment.article.id
-        if comment.author == user:
-            comment.delete()
-            return HttpResponse(article_id, status=200)
+        if (handle == "edit"):
+            edit_comment = Comment.objects.get(pk=comment_id)
+            edit_comment.content = content
+            edit_comment.save()
+            return HttpResponse(status=201)
         else:
-            return HttpResponseForbidden()
+            Comment.objects.get(pk=comment_id).delete()
+            return HttpResponse(status=204)

--- a/backend/SNUBot/community/views.py
+++ b/backend/SNUBot/community/views.py
@@ -324,6 +324,7 @@ def comment(request, id):
     if not request.user.is_authenticated:
         return HttpResponse(status=401)
     user = request.user
+
     if request.method == "POST":
         try:
             req_data = json.loads(request.body.decode())
@@ -338,19 +339,27 @@ def comment(request, id):
         )
         comment_json = list(comments)
         return JsonResponse(comment_json, status=201, safe=False)
+
     if request.method == "PUT":
         try:
             req_data = json.loads(request.body.decode())
             comment_id = req_data["commentId"]
             content = req_data["content"]
-            handle = req_data["handle"]
         except (KeyError, JSONDecodeError):
             return HttpResponseBadRequest()
-        if (handle == "edit"):
-            edit_comment = Comment.objects.get(pk=comment_id)
-            edit_comment.content = content
-            edit_comment.save()
-            return HttpResponse(status=201)
-        else:
-            Comment.objects.get(pk=comment_id).delete()
-            return HttpResponse(status=204)
+
+        edit_comment = get_object_or_404(Comment, pk=comment_id)
+        edit_comment.content = content
+        edit_comment.save()
+        return HttpResponse(status=201)
+
+    if request.method == "DELETE":
+        try:
+            req_data = json.loads(request.body.decode())
+            comment_id = req_data["commentId"]
+        except (KeyError, JSONDecodeError):
+            return HttpResponseBadRequest()
+
+        article_to_delete = get_object_or_404(Comment, pk=comment_id)
+        article_to_delete.delete()
+        return HttpResponse(status=204)

--- a/backend/SNUBot/community/views.py
+++ b/backend/SNUBot/community/views.py
@@ -339,17 +339,11 @@ def comment(request, id):
         comment_json = list(comments)
         return JsonResponse(comment_json, status=201, safe=False)
     if request.method == "PUT":
-        print('put call')
         try:
-            print('1')
             req_data = json.loads(request.body.decode())
-            print('2')
             comment_id = req_data["commentId"]
-            print('3')
             content = req_data["content"]
-            print('4')
             handle = req_data["handle"]
-            print('6')
         except (KeyError, JSONDecodeError):
             return HttpResponseBadRequest()
         if (handle == "edit"):

--- a/frontend/src/components/ArticleDetail/ArticleDetail.js
+++ b/frontend/src/components/ArticleDetail/ArticleDetail.js
@@ -32,9 +32,10 @@ const ArticleDetail = (props) => {
   const [newComment, setComment] = useState('');
   const [showLogin, setShowLogin] = useState(false);
   const [edit, setEdit] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
 
   const {
-    show, onHide, article, postComment, like, dislike,
+    show, onHide, article, postComment, deleteArticle, like, dislike,
   } = props;
 
   const makeCommentEntry = (comment) => (
@@ -98,6 +99,17 @@ const ArticleDetail = (props) => {
                     onClick={() => setEdit(true)}
                   >
                     Edit
+                  </Button>
+                  {' '}
+                  <Button
+                    id="article-delete-button"
+                    onClick={() => setShowDelete(true)}
+                  // onClick={() => {
+                  //   deleteArticle(article.id);
+                  //   onHide();
+                  // }}
+                  >
+                    Delete
                   </Button>
                 </Col>
               )
@@ -173,7 +185,37 @@ const ArticleDetail = (props) => {
         id={article.id}
         title={articleTitle}
         content={articleContent}
+        className="article-edit-card"
       />
+      <Modal
+        show={showDelete}
+        onHide={() => {
+          setShowDelete(false);
+          onHide();
+        }}
+      >
+        <Modal.Header closeButton>
+          <h5>Are you sure to delete?</h5>
+        </Modal.Header>
+        <Modal.Footer>
+          <Button
+            id="delete-confirm-yes"
+            onClick={() => {
+              deleteArticle(article.id);
+              onHide();
+              setShowDelete(false);
+            }}
+          >
+            Yes
+          </Button>
+          <Button
+            id="delete-confirm-no"
+            onClick={() => setShowDelete(false)}
+          >
+            No
+          </Button>
+        </Modal.Footer>
+      </Modal>
     </div>
   );
 };
@@ -181,6 +223,9 @@ const ArticleDetail = (props) => {
 const mapDispatchToProps = (dispatch) => ({
   postComment: (id, comment) => dispatch(
     actionCreators.postComment(id, comment),
+  ),
+  deleteArticle: (id) => dispatch(
+    actionCreators.deleteArticle(id),
   ),
   like: (id) => dispatch(
     actionCreators.putVote('like', id),
@@ -197,6 +242,7 @@ export default connect(
 
 ArticleDetail.propTypes = {
   postComment: PropTypes.func.isRequired,
+  deleteArticle: PropTypes.func.isRequired,
   like: PropTypes.func.isRequired,
   dislike: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,

--- a/frontend/src/components/ArticleDetail/ArticleDetail.test.js
+++ b/frontend/src/components/ArticleDetail/ArticleDetail.test.js
@@ -14,7 +14,7 @@ const stubArticleNormal = {
     id: 1,
     title: 'TEST_ARTICLE_TITLE_1',
     content: 'TEST_ARTICLE_CONTENT_1',
-    author: 'TEST_AUTHOR',
+    author__nickname: 'TEST_AUTHOR',
     dislike: 4,
     like: 10,
     vote_diff: 6,
@@ -213,5 +213,62 @@ describe('<ArticleDetail />', () => {
     commentButton.simulate('click');
     expect(spyPostComment).toHaveBeenCalledTimes(0);
     expect(commentInput.instance().value).toEqual('new comment');
+  });
+  it('edit', () => {
+    sessionStorage.setItem('nickname', 'TEST_AUTHOR');
+    const wrapper = mount(
+      <Provider store={mockStore}>
+        <ArticleDetail
+          article={stubArticleNormal.article}
+          key={stubArticleNormal.article.id}
+          onHide={spyOnHide}
+          show
+        />
+      </Provider>,
+    );
+    const editButton = wrapper.find('#article-edit-button').at(1);
+    expect(editButton.exists()).toBeTruthy();
+
+    editButton.simulate('click');
+
+    const editCard = wrapper.find('.article-edit-card');
+    expect(editCard.exists()).toBeTruthy();
+
+    sessionStorage.clear();
+  });
+  it('delete', () => {
+    sessionStorage.setItem('nickname', 'TEST_AUTHOR');
+    const spyDelete = jest
+      .spyOn(ActionCreators, 'deleteArticle')
+      .mockImplementation(() => (dispatch) => { });
+    const wrapper = mount(
+      <Provider store={mockStore}>
+        <ArticleDetail
+          article={stubArticleNormal.article}
+          key={stubArticleNormal.article.id}
+          onHide={spyOnHide}
+          show
+        />
+      </Provider>,
+    );
+    const deleteButton = wrapper.find('#article-delete-button').at(1);
+    expect(deleteButton.exists()).toBeTruthy();
+
+    deleteButton.simulate('click');
+
+    const deleteNoButton = wrapper.find('#delete-confirm-no').at(1);
+    expect(deleteNoButton.exists()).toBeTruthy();
+
+    deleteNoButton.simulate('click');
+    deleteButton.simulate('click');
+
+    const deleteYesButton = wrapper.find('#delete-confirm-yes').at(1);
+    expect(deleteYesButton.exists()).toBeTruthy();
+
+    expect(spyDelete).not.toHaveBeenCalled();
+    deleteYesButton.simulate('click');
+    expect(spyDelete).toHaveBeenCalledTimes(1);
+
+    sessionStorage.clear();
   });
 });

--- a/frontend/src/components/ArticleEntry/ArticleEntry.test.js
+++ b/frontend/src/components/ArticleEntry/ArticleEntry.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import { getMockStore } from '../../test-utils/mocks';
 
+import * as ActionCreators from '../../store/actions/article';
 import ArticleEntry from './ArticleEntry';
 
 const stubArticleInitialState = {
@@ -61,5 +62,19 @@ describe('<ArticleEntry />', () => {
     const wrapper = component.find('#article-entry').at(1);
     wrapper.simulate('focus');
     wrapper.simulate('blur');
+  });
+  it('fetch when clicked, clear when closed', () => {
+    const wrapper = mount(articleEntry);
+    const clickable = wrapper.find('#article-entry').at(1);
+    const spyFetch = jest
+      .spyOn(ActionCreators, 'fetchArticle')
+      // eslint-disable-next-line no-unused-vars
+      .mockImplementation(() => (dispatch) => { });
+
+    expect(spyFetch).not.toHaveBeenCalled();
+    expect(clickable.exists()).toBeTruthy();
+    clickable.simulate('click');
+
+    expect(spyFetch).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/Comment/Comment.js
+++ b/frontend/src/components/Comment/Comment.js
@@ -10,7 +10,7 @@ import * as actionCreators from '../../store/actions';
 
 const Comment = (props) => {
   const {
-    author, content, editComment, articleId, commentId,
+    author, content, editComment, deleteComment, articleId, commentId,
   } = props;
   const [edit, setEdit] = useState(false);
   const [newContent, setNewContent] = useState(content);
@@ -31,12 +31,21 @@ const Comment = (props) => {
             {
               isAuthor
                 ? (
-                  <Button
-                    id="comment-edit-button"
-                    onClick={() => setEdit(true)}
-                  >
-                    Edit
-                  </Button>
+                  <div id="author-only">
+                    <Button
+                      id="comment-edit-button"
+                      onClick={() => setEdit(true)}
+                    >
+                      Edit
+                    </Button>
+                    {' '}
+                    <Button
+                      id="comment-delete-button"
+                      onClick={() => deleteComment(articleId, commentId)}
+                    >
+                      Delete
+                    </Button>
+                  </div>
                 )
                 : <div />
             }
@@ -71,6 +80,9 @@ const mapDispatchToProps = (dispatch) => ({
   editComment: (id, commentId, comment) => dispatch(
     actionCreators.editComment(id, commentId, comment),
   ),
+  deleteComment: (articleId, commentId) => dispatch(
+    actionCreators.deleteComment(articleId, commentId),
+  ),
 });
 
 export default connect(
@@ -80,6 +92,7 @@ export default connect(
 
 Comment.propTypes = {
   editComment: PropTypes.func.isRequired,
+  deleteComment: PropTypes.func.isRequired,
   articleId: PropTypes.number,
   commentId: PropTypes.number.isRequired,
   author: PropTypes.string.isRequired,

--- a/frontend/src/store/actions/article.js
+++ b/frontend/src/store/actions/article.js
@@ -48,7 +48,6 @@ export const editArticle = (id, title, content) => (dispatch) => (
       type: EDIT_ARTICLE,
       article: res.data,
     });
-    // dispatch(push('/boards'));
   })
 );
 
@@ -57,7 +56,7 @@ export const deleteArticle = (id) => (dispatch) => (
     dispatch({
       type: DELETE_ARTICLE,
     });
-    dispatch(push('/articles'));
+    window.location.reload();
   })
 );
 

--- a/frontend/src/store/actions/article.test.js
+++ b/frontend/src/store/actions/article.test.js
@@ -166,6 +166,10 @@ describe('action article', () => {
   });
 
   it("'deleteArticle' should delete Article correctly", (done) => {
+    const { location } = window;
+    delete window.location;
+    window.location = { reload: jest.fn() };
+
     const spy = jest.spyOn(axios, 'delete').mockImplementation(
       (id) => new Promise((resolve) => {
         const result = {
@@ -175,8 +179,11 @@ describe('action article', () => {
       }),
     );
 
+    expect(window.location.reload).not.toHaveBeenCalled();
     store.dispatch(actionCreators.deleteArticle()).then(() => {
       expect(spy).toHaveBeenCalledTimes(1);
+      expect(window.location.reload).toHaveBeenCalled();
+      window.location = location;
       done();
     });
   });

--- a/frontend/src/store/actions/comment.js
+++ b/frontend/src/store/actions/comment.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import {
   FETCH_COMMENT,
   CLEAR_COMMENT,
-  // DELETE_COMMENT,
+  DELETE_COMMENT,
   POST_COMMENT,
   EDIT_COMMENT,
 } from './types';
@@ -33,9 +33,11 @@ export const postComment = (articleId, content) => (dispatch) => (
   })
 );
 
-export const editComment = (articleId, commentId, content) => (dispatch) => (
+export const editComment = (
+  articleId, commentId, content, handle = 'edit',
+) => (dispatch) => (
   axios.put(`/api/comment/${articleId}/`, {
-    commentId, content,
+    commentId, content, handle,
   }).then(() => {
     dispatch({
       id: commentId,
@@ -45,13 +47,15 @@ export const editComment = (articleId, commentId, content) => (dispatch) => (
   })
 );
 
-// export const deleteComment = (id) => (dispatch) => (
-//   axios.delete(`${remoteURL}/api/comment/${id}/`).then((res) => {
-//     const article_id = res;
-//     fetchComment(articleId);
-//     // dispatch({
-//     //   type: DELETE_COMMENT,
-//     //   deleted_id: id,
-//     // })
-//   })
-// )
+export const deleteComment = (
+  articleId, commentId, content = '', handle = 'delete',
+) => (dispatch) => (
+  axios.put(`/api/comment/${articleId}/`, {
+    commentId, content, handle,
+  }).then(() => {
+    dispatch({
+      type: DELETE_COMMENT,
+      deletedCommentId: commentId,
+    });
+  })
+);

--- a/frontend/src/store/actions/comment.js
+++ b/frontend/src/store/actions/comment.js
@@ -34,10 +34,10 @@ export const postComment = (articleId, content) => (dispatch) => (
 );
 
 export const editComment = (
-  articleId, commentId, content, handle = 'edit',
+  articleId, commentId, content,
 ) => (dispatch) => (
   axios.put(`/api/comment/${articleId}/`, {
-    commentId, content, handle,
+    commentId, content,
   }).then(() => {
     dispatch({
       id: commentId,
@@ -48,10 +48,10 @@ export const editComment = (
 );
 
 export const deleteComment = (
-  articleId, commentId, content = '', handle = 'delete',
+  articleId, commentId,
 ) => (dispatch) => (
-  axios.put(`/api/comment/${articleId}/`, {
-    commentId, content, handle,
+  axios.delete(`/api/comment/${articleId}/`, {
+    data: { commentId: commentId.toString() },
   }).then(() => {
     dispatch({
       type: DELETE_COMMENT,

--- a/frontend/src/store/actions/comment.test.js
+++ b/frontend/src/store/actions/comment.test.js
@@ -10,12 +10,12 @@ const stubComment = {
   author_id: 1,
 };
 const stubPostedComment = {
-  id: 1,
+  id: 2,
   content: 'content 2',
   author_id: 1,
 };
 const edittedComment = {
-  id: 1,
+  id: 3,
   content: 'editted',
   author_id: 1,
 };
@@ -26,53 +26,49 @@ const stubCommentList1 = [
     author_id: 1,
   },
   {
-    id: 1,
-    content: 'content 1',
+    id: 2,
+    content: 'content 2',
     author_id: 1,
   },
   {
-    id: 1,
-    content: 'content 1',
+    id: 3,
+    content: 'content 3',
     author_id: 1,
   },
 ];
 const stubCommentList2 = [
   {
-    id: 2,
-    content: 'content 2',
-    author_id: 2,
+    id: 1,
+    content: 'editted',
+    author_id: 1,
   },
   {
     id: 2,
     content: 'content 2',
-    author_id: 2,
+    author_id: 1,
   },
   {
-    id: 2,
-    content: 'content 2',
-    author_id: 2,
+    id: 3,
+    content: 'content 3',
+    author_id: 1,
   },
 ];
 const stubCommentList3 = [
   {
+    id: 2,
+    content: 'content 2',
+    author_id: 1,
+  },
+  {
     id: 3,
     content: 'content 3',
-    author_id: 3,
-  },
-  {
-    id: 4,
-    content: 'content 4',
-    author_id: 4,
-  },
-  {
-    id: 5,
-    content: 'content 5',
-    author_id: 5,
+    author_id: 1,
   },
 ];
 describe('action comment', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    store.dispatch(actionCreators.clearComment());
   });
   // 여기부터 다시
   it("'fetchComment' should fetch Comments correctly", (done) => {
@@ -135,7 +131,7 @@ describe('action comment', () => {
       (id) => new Promise((resolve) => {
         const result = {
           status: 200,
-          data: stubComment,
+          data: stubCommentList1,
         };
         resolve(result);
       }),
@@ -143,18 +139,55 @@ describe('action comment', () => {
 
     store.dispatch(actionCreators.fetchComment(0)).then(() => {
       const newState = store.getState();
-      expect(newState.comment.commentList).toBe(stubComment);
+      expect(newState.comment.commentList)
+        .toMatchObject(stubCommentList1);
       expect(spyFetch).toHaveBeenCalledTimes(1);
-      done();
-    });
 
-    store
-      .dispatch(actionCreators.editComment(1, 1, 'editted'))
-      .then(() => {
-        const newState = store.getState();
-        expect(newState.comment.commentList).toBe(edittedComment);
-        expect(spyEdit).toHaveBeenCalledTimes(1);
-        done();
-      });
+      store
+        .dispatch(actionCreators.editComment(1, 1, 'editted'))
+        .then(() => {
+          const editState = store.getState();
+          expect(editState.comment.commentList)
+            .toMatchObject(stubCommentList2);
+          expect(spyEdit).toHaveBeenCalledTimes(1);
+          done();
+        });
+    });
+  });
+  it('delete comment', (done) => {
+    const spyFetch = jest.spyOn(axios, 'get').mockImplementation(
+      (id) => new Promise((resolve) => {
+        const result = {
+          status: 200,
+          data: stubCommentList1,
+        };
+        resolve(result);
+      }),
+    );
+    const spyDelete = jest.spyOn(axios, 'put').mockImplementation(
+      (id, commentId) => new Promise((resolve) => {
+        const result = {
+          status: 200,
+        };
+        resolve(result);
+      }),
+    );
+
+    store.dispatch(actionCreators.fetchComment(0)).then(() => {
+      const newState = store.getState();
+      expect(newState.comment.commentList)
+        .toMatchObject(stubCommentList1);
+      expect(spyFetch).toHaveBeenCalledTimes(1);
+      store
+        .dispatch(actionCreators.deleteComment(1, 1))
+        .then(() => {
+          const delState = store.getState();
+          expect(delState.comment.commentList)
+            .toMatchObject(stubCommentList3);
+          expect(spyDelete).toHaveBeenCalledTimes(1);
+
+          done();
+        });
+    });
   });
 });

--- a/frontend/src/store/actions/comment.test.js
+++ b/frontend/src/store/actions/comment.test.js
@@ -164,10 +164,10 @@ describe('action comment', () => {
         resolve(result);
       }),
     );
-    const spyDelete = jest.spyOn(axios, 'put').mockImplementation(
+    const spyDelete = jest.spyOn(axios, 'delete').mockImplementation(
       (id, commentId) => new Promise((resolve) => {
         const result = {
-          status: 200,
+          status: 204,
         };
         resolve(result);
       }),

--- a/frontend/src/store/actions/index.js
+++ b/frontend/src/store/actions/index.js
@@ -31,6 +31,6 @@ export {
   fetchComment,
   clearComment,
   postComment,
-  // deleteComment,
+  deleteComment,
   editComment,
 } from './comment';

--- a/frontend/src/store/actions/types.js
+++ b/frontend/src/store/actions/types.js
@@ -39,6 +39,6 @@ export const CLEAR_CHAT_HISTORY = 'CLEAR_CHAT_HISTORY';
 // Comment
 export const FETCH_COMMENT = 'FETCH_COMMENT';
 export const CLEAR_COMMENT = 'CLEAR_COMMENT';
-// export const DELETE_COMMENT = 'DELETE_COMMENT';
+export const DELETE_COMMENT = 'DELETE_COMMENT';
 export const POST_COMMENT = 'POST_COMMENT';
 export const EDIT_COMMENT = 'EDIT_COMMENT';

--- a/frontend/src/store/reducers/Comment.js
+++ b/frontend/src/store/reducers/Comment.js
@@ -1,7 +1,7 @@
 import {
   FETCH_COMMENT,
   CLEAR_COMMENT,
-  // DELETE_COMMENT,
+  DELETE_COMMENT,
   POST_COMMENT,
   EDIT_COMMENT,
 } from '../actions/types';
@@ -19,11 +19,16 @@ export default function (state = initialState, action = defaultAction) {
     case CLEAR_COMMENT: {
       return { ...state, commentList: [] };
     }
-    // TODO : delete on comment and article
-    // case DELETE_COMMENT: {
-    // deleted_id = action.deleted_id;
-    // return { ...state };
-    // }
+    case DELETE_COMMENT: {
+      const delCommentId = action.deletedCommentId;
+      const index = state.commentList.findIndex(
+        (comment) => comment.id === delCommentId,
+      );
+      const head = state.commentList.slice(0, index);
+      const tail = state.commentList.slice(index + 1);
+      const newCommentList = head.concat(tail);
+      return { ...state, commentList: newCommentList };
+    }
     case POST_COMMENT: {
       return { ...state, commentList: action.comment };
     }


### PR DESCRIPTION
* 백엔드 `delete` 구현 (`DELETE`가 아닌 `PUT`에 구현함, `DELETE`로 하면 인풋을 두 개 받지못함)
* 프론트엔드 `delete` 구현
* 테스트코드 수정/작성