### PR TITLE
fix edit bug, Issue #152

### DIFF
--- a/frontend/src/components/ArticleCreate/ArticleCreate.js
+++ b/frontend/src/components/ArticleCreate/ArticleCreate.js
@@ -16,12 +16,15 @@ const ArticleCreate = (props) => {
   const [key, setKey] = useState('write');
 
   const requiresLogin = (sessionStorage.getItem('username') === null);
+  console.log(show)
 
-  if (articleTitle === '' && articleTitle !== title) {
-    setTitle(title);
-  }
-  if (articleContent === '' && articleContent !== content) {
-    setContent(content);
+  if (show) {
+    if (articleTitle === '' && articleTitle !== title) {
+      setTitle(title);
+    }
+    if (articleContent === '' && articleContent !== content) {
+      setContent(content);
+    }
   }
 
   return (

--- a/frontend/src/components/ArticleCreate/ArticleCreate.js
+++ b/frontend/src/components/ArticleCreate/ArticleCreate.js
@@ -16,7 +16,6 @@ const ArticleCreate = (props) => {
   const [key, setKey] = useState('write');
 
   const requiresLogin = (sessionStorage.getItem('username') === null);
-  console.log(show)
 
   if (show) {
     if (articleTitle === '' && articleTitle !== title) {


### PR DESCRIPTION
#152 
기존에 Edit을 부르면 articleTitle과 articleContent가 비어있어야 props로 받은 title, content를 넣어주는 방식이었는데, 이게 show만 false일 뿐 rendering은 돼서 만약 다른 article을 누르면 해당 article의 title과 content가 state에 이미 들어가버려 edit하는 article이 아닌 페이지에 들어온 뒤 가장 처음 본 aritcle의 title정보와 content 정보를 보여줬습니다.
따라서 articleCreate에서 show가 활성화 될 때 articleTitle과 articleContent를 받아오는 방식으로 바꿨습니다.
