### PR TITLE
Fix password clear, Issue #166

### DIFF
--- a/frontend/src/containers/User/Signup/Signup.js
+++ b/frontend/src/containers/User/Signup/Signup.js
@@ -40,7 +40,9 @@ class Signup extends Component {
     // length같은 기준을 정해야 할 것 같습니다.
     const SignupHandler = () => {
       if (password.length < 8) {
-        this.setState({ validPassword: false, validPasswordConfirm: true, password: '', passwordConfirm: '' });
+        this.setState({
+          validPassword: false, validPasswordConfirm: true, password: '', passwordConfirm: '',
+        });
       } else if (password !== passwordConfirm) {
         this.setState({ validPasswordConfirm: false, validPassword: true, passwordConfirm: '' });
       } else {

--- a/frontend/src/containers/User/Signup/Signup.js
+++ b/frontend/src/containers/User/Signup/Signup.js
@@ -39,11 +39,10 @@ class Signup extends Component {
     // 예를 들어 nickname이 공백인 경우 400을 반환하는게 아니라, 공백인 닉네임을 가진 유저가 생성되어서
     // length같은 기준을 정해야 할 것 같습니다.
     const SignupHandler = () => {
-      this.setState({ password: '', passwordConfirm: '' });
       if (password.length < 8) {
-        this.setState({ validPassword: false, validPasswordConfirm: true });
+        this.setState({ validPassword: false, validPasswordConfirm: true, password: '', passwordConfirm: '' });
       } else if (password !== passwordConfirm) {
-        this.setState({ validPasswordConfirm: false, validPassword: true });
+        this.setState({ validPasswordConfirm: false, validPassword: true, passwordConfirm: '' });
       } else {
         this.setState({ validPassword: true, validPasswordConfirm: true });
         signup(email, username, nickname, password);

--- a/frontend/src/containers/User/Signup/Signup.test.js
+++ b/frontend/src/containers/User/Signup/Signup.test.js
@@ -93,7 +93,7 @@ describe('<Signup />', () => {
     expect(passwordInput.instance().value).toEqual(validPassword);
     expect(passwordConfirmInput.instance().value).toEqual(typoPassword);
     buttonInput.simulate('click');
-    expect(passwordInput.instance().value).toEqual('');
+    expect(passwordInput.instance().value).toEqual(validPassword);
     expect(passwordConfirmInput.instance().value).toEqual('');
   });
 
@@ -129,8 +129,8 @@ describe('<Signup />', () => {
     buttonInput.simulate('click');
 
     expect(historyMock.push).toHaveBeenCalledTimes(1);
-    expect(passwordInput.instance().value).toEqual('');
-    expect(passwordConfirmInput.instance().value).toEqual('');
+    expect(passwordInput.instance().value).toEqual(validPassword);
+    expect(passwordConfirmInput.instance().value).toEqual(validPassword);
     expect(spySignup).toHaveBeenCalledTimes(1);
     expect(spySignup).toHaveBeenCalledWith(
       validEmail,
@@ -177,8 +177,8 @@ describe('<Signup />', () => {
     buttonInput.simulate('click');
 
     expect(historyMock.push).toHaveBeenCalledTimes(0);
-    expect(passwordInput.instance().value).toEqual('');
-    expect(passwordConfirmInput.instance().value).toEqual('');
+    expect(passwordInput.instance().value).toEqual(validPassword);
+    expect(passwordConfirmInput.instance().value).toEqual(validPassword);
     expect(spySignup).toHaveBeenCalledTimes(1);
     expect(spySignup).toHaveBeenCalledWith(
       validEmail,

--- a/frontend/src/store/reducers/User.js
+++ b/frontend/src/store/reducers/User.js
@@ -38,7 +38,7 @@ export default function (state = initialState, action = defaultAction) {
     }
     case SIGN_UP: {
       return {
-        ...state, signupCreateFail: false, signupSubmitFail: true, signinFail: false,
+        ...state, signupCreateFail: false, signupSubmitFail: false, signinFail: false,
       };
     }
     case CHANGE_INFO_FAIL: {
@@ -73,7 +73,7 @@ export default function (state = initialState, action = defaultAction) {
         changeInfoSuccess: false,
         signinFail: false,
         signupCreateFail: false,
-        signupSubmitFail: true,
+        signupSubmitFail: false,
       };
   }
 }


### PR DESCRIPTION
password refresh 되는 방식을 바꿨습니다.
password validation 실패 시 모두 초기화, password confirm validation 실패 시 password confirm만 초기화, 이외에 backend로 요청을 보내는데 성공한 경우에는 초기화를 안시키는 방식으로 바꿨습니다.
